### PR TITLE
Law/update chart for k8s 1.22

### DIFF
--- a/helm/helloworld/templates/ingress.yaml
+++ b/helm/helloworld/templates/ingress.yaml
@@ -36,12 +36,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
-            {{- end }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/helm/helloworld/values.yaml
+++ b/helm/helloworld/values.yaml
@@ -50,7 +50,7 @@ ingress:
   hosts:
     - host: chart-example.local
       paths:
-        - path: /*
+        - path: /
           pathType: Prefix
   tls: []
   #  - secretName: chart-example-tls

--- a/helm/helloworld/values.yaml
+++ b/helm/helloworld/values.yaml
@@ -51,6 +51,7 @@ ingress:
     - host: chart-example.local
       paths:
         - path: /*
+          pathType: Prefix
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
Specifically, the new Ingress format for 1.22 is:
```
# Source: helloworld/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: helloworld
  labels:
    helm.sh/chart: helloworld-0.1.2
    app.kubernetes.io/name: helloworld
    app.kubernetes.io/instance: helloworld
    app.kubernetes.io/version: "0.0.2"
    app.kubernetes.io/managed-by: Helm
  annotations:
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/target-type: ip
    kubernetes.io/ingress.class: alb
spec:
  rules:
    - http:
        paths:
          - path: /*
            pathType: Prefix
            backend:
              service:
                name: helloworld
                port:
                  number: 80

``` 

note the addition of `spec.rules.http.paths.path[pathtype]`, and the refactor of spec.rules.http.paths.backend.service to use `service.name` and `service.name.port.number` instead of the legacy serviceName and servicePort.  